### PR TITLE
feat: guard dcl

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,12 +85,19 @@ WARNING:  lo_guard: lobject "be_lo_create" function call, sentinel entry written
 (1 row)
 ```
 
+Sentinel logging for data control statements (role and membership changes that do not fire event triggers) can be enabled with `ddl_guard.dcl_sentinel`.
+
+```sql
+ALTER SYSTEM SET ddl_guard.dcl_sentinel = on;
+```
+
 ## Configuration
 
 The following configuration options are available:
 
 - `ddl_guard.enabled`: Enables or disables the extension. Default is `off`.
 - `ddl_guard.ddl_sentinel`: Enables "sentinel mode" for DDL. Default is `off`.
+- `ddl_guard.dcl_sentinel`: Enables "sentinel mode" for data control statements. Default is `off`.
 - `ddl_guard.lo_sentinel`: Enables "sentinel mode" for large objects. Default is `off`.
 
 ## License

--- a/test/ddl_guard.conf
+++ b/test/ddl_guard.conf
@@ -1,4 +1,5 @@
 shared_preload_libraries = 'ddl_guard'
 ddl_guard.enabled = on
 ddl_guard.ddl_sentinel = on
+ddl_guard.dcl_sentinel = on
 ddl_guard.lo_sentinel = on

--- a/test/regular/expected/dcl.out
+++ b/test/regular/expected/dcl.out
@@ -1,0 +1,8 @@
+CREATE TABLE ddl_guard_dcl_test (id int);
+WARNING:  ddl_guard: ddl detected, sentinel entry written
+GRANT SELECT ON ddl_guard_dcl_test TO PUBLIC;
+WARNING:  ddl_guard: ddl detected, sentinel entry written
+REVOKE SELECT ON ddl_guard_dcl_test FROM PUBLIC;
+WARNING:  ddl_guard: ddl detected, sentinel entry written
+DROP TABLE ddl_guard_dcl_test;
+WARNING:  ddl_guard: ddl detected, sentinel entry written

--- a/test/regular/expected/sentinel.out
+++ b/test/regular/expected/sentinel.out
@@ -1,7 +1,7 @@
 SELECT count(*) AS before_count FROM ddl_guard.sentinel_log;
  before_count 
 --------------
-          145
+          149
 (1 row)
 
 \gset

--- a/test/regular/sql/dcl.sql
+++ b/test/regular/sql/dcl.sql
@@ -1,0 +1,4 @@
+CREATE TABLE ddl_guard_dcl_test (id int);
+GRANT SELECT ON ddl_guard_dcl_test TO PUBLIC;
+REVOKE SELECT ON ddl_guard_dcl_test FROM PUBLIC;
+DROP TABLE ddl_guard_dcl_test;

--- a/test/superuser/expected/dcl.out
+++ b/test/superuser/expected/dcl.out
@@ -1,0 +1,22 @@
+SET ddl_guard.dcl_sentinel = off;
+DROP ROLE IF EXISTS ddl_guard_dcl_role;
+NOTICE:  role "ddl_guard_dcl_role" does not exist, skipping
+DROP ROLE IF EXISTS ddl_guard_dcl_member;
+NOTICE:  role "ddl_guard_dcl_member" does not exist, skipping
+SET ddl_guard.dcl_sentinel = on;
+CREATE ROLE ddl_guard_dcl_role;
+WARNING:  ddl_guard: dcl detected, sentinel entry written
+CREATE ROLE ddl_guard_dcl_member;
+WARNING:  ddl_guard: dcl detected, sentinel entry written
+GRANT ddl_guard_dcl_role TO ddl_guard_dcl_member;
+WARNING:  ddl_guard: dcl detected, sentinel entry written
+REVOKE ddl_guard_dcl_role FROM ddl_guard_dcl_member;
+WARNING:  ddl_guard: dcl detected, sentinel entry written
+SET ddl_guard.dcl_sentinel = off;
+SET ROLE ddl_guard_dcl_member;
+GRANT ddl_guard_dcl_role TO ddl_guard_dcl_member;
+ERROR:  Non-superusers are not allowed to execute data control statements
+HINT:  ddl_guard.enabled is set.
+RESET ROLE;
+DROP ROLE ddl_guard_dcl_member;
+DROP ROLE ddl_guard_dcl_role;

--- a/test/superuser/sql/dcl.sql
+++ b/test/superuser/sql/dcl.sql
@@ -1,0 +1,14 @@
+SET ddl_guard.dcl_sentinel = off;
+DROP ROLE IF EXISTS ddl_guard_dcl_role;
+DROP ROLE IF EXISTS ddl_guard_dcl_member;
+SET ddl_guard.dcl_sentinel = on;
+CREATE ROLE ddl_guard_dcl_role;
+CREATE ROLE ddl_guard_dcl_member;
+GRANT ddl_guard_dcl_role TO ddl_guard_dcl_member;
+REVOKE ddl_guard_dcl_role FROM ddl_guard_dcl_member;
+SET ddl_guard.dcl_sentinel = off;
+SET ROLE ddl_guard_dcl_member;
+GRANT ddl_guard_dcl_role TO ddl_guard_dcl_member;
+RESET ROLE;
+DROP ROLE ddl_guard_dcl_member;
+DROP ROLE ddl_guard_dcl_role;


### PR DESCRIPTION
Data Control Language (DCL) is not logically replicated, so it needs to be guarded against.